### PR TITLE
mv: unify service.yaml

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,105 +1,32 @@
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "microverse.name" . }}
-  labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
-    heritage: Tiller
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
-spec:
-  tls:
-    - hosts:
-        - app.{{ .Values.domain }}
-      secretName: microverse-app-tls
-  rules:
-    - host: app.{{ .Values.domain }}
-      http:
-        paths:
-          - path: /{{ .Values.name }}
-            backend:
-              serviceName: {{ template "microverse.name" . }}
-              servicePort: 80
+{{- $context := . -}}    
+{{- range .Values.ports }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: microverse-dashboard-{{ .Values.name }}
+  name: microverse-{{ .name }}-{{ $context.Values.name }}
   labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
+    app: {{ template "microverse.name" $context }}
+    chart: {{ template "microverse.name" $context }}-0.0.1
+    release: {{ $context.Values.name }}
     heritage: Tiller
   annotations:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
+    nginx.org/websocket-services: microverse-{{ .name }}-{{ $context.Values.name }}
 spec:
   tls:
     - hosts:
-        - dashboard.{{ .Values.domain }}
-      secretName: microverse-dashboard-tls
+        - {{ .name }}.{{ $context.Values.domain }}
+      secretName: microverse-{{ .name }}-tls
   rules:
-    - host: dashboard.{{ .Values.domain }}
+    - host: {{ .name }}.{{ $context.Values.domain }}
       http:
         paths:
-          - path: /{{ .Values.name }}
+          - path: /{{ $context.Values.name }}
             backend:
-              serviceName: microverse-dashboard-{{ .Values.name }}
+              serviceName: microverse-{{ .name }}-{{ $context.Values.name }}
               servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: microverse-ice-{{ .Values.name }}
-  labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
-    heritage: Tiller
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
-    nginx.org/websocket-services: microverse-ice-{{ .Values.name }}
-spec:
-  tls:
-    - hosts:
-        - ice.{{ .Values.domain }}
-      secretName: microverse-ice-tls
-  rules:
-    - host: ice.{{ .Values.domain }}
-      http:
-        paths:
-          - path: /{{ .Values.name }}
-            backend:
-              serviceName: microverse-ice-{{ .Values.name }}
-              servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: microverse-bootstrap-{{ .Values.name }}
-  labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
-    heritage: Tiller
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
-    nginx.org/websocket-services: microverse-bootstrap-{{ .Values.name }}
-spec:
-  tls:
-    - hosts:
-        - bootstrap.{{ .Values.domain }}
-      secretName: microverse-ice-tls
-  rules:
-    - host: bootstrap.{{ .Values.domain }}
-      http:
-        paths:
-          - path: /{{ .Values.name }}
-            backend:
-              serviceName: microverse-bootstrap-{{ .Values.name }}
-              servicePort: 80
+
+{{- end }}
+

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,79 +1,25 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "microverse.name" . }}
-  labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
-    heritage: Tiller
-spec:
-  type: ClusterIP
-  ports:
-  - port: 80
-    targetPort: 3000
-    protocol: TCP
-    name: app
-  selector:
-    app: {{ template "microverse.name" . }}
-    release: {{ .Values.name }}
+{{- $context := . -}}    
+{{- range .Values.ports }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: microverse-dashboard-{{ .Values.name }}
+  name: microverse-{{ .name }}-{{ $context.Values.name }}
   labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
+    app: {{ template "microverse.name" $context }}
+    chart: {{ template "microverse.name" $context }}-0.0.1
+    release: {{ $context.Values.name }}
     heritage: Tiller
 spec:
   type: ClusterIP
   ports:
   - port: 80
-    targetPort: 3030
+    targetPort: {{ .port }}
     protocol: TCP
-    name: dashboard
+    name: {{ .name }}
   selector:
-    app: {{ template "microverse.name" . }}
-    release: {{ .Values.name }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: microverse-ice-{{ .Values.name }}
-  labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
-    heritage: Tiller
-spec:
-  type: ClusterIP
-  ports:
-  - port: 80
-    targetPort: 3033
-    protocol: TCP
-    name: ice
-  selector:
-    app: {{ template "microverse.name" . }}
-    release: {{ .Values.name }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: microverse-bootstrap-{{ .Values.name }}
-  labels:
-    app: {{ template "microverse.name" . }}
-    chart: {{ template "microverse.name" . }}-0.0.1
-    release: {{ .Values.name }}
-    heritage: Tiller
-spec:
-  type: ClusterIP
-  ports:
-  - port: 80
-    targetPort: 3040
-    protocol: TCP
-    name: bootstrap
-  selector:
-    app: {{ template "microverse.name" . }}
-    release: {{ .Values.name }}
+    app: {{ template "microverse.name" $context }}
+    release: {{ $context.Values.name }}
+{{- end }}
+
+


### PR DESCRIPTION
```
➜  microverse-app git:(simplify) ✗ diff ./old.txt new.txt
2a3,4
>
> ---
6c8
<   name: microverse-app-cihangir
---
>   name: microverse-ice-cihangir
16c18
<     targetPort: 3000
---
>     targetPort: 3033
18c20
<     name: app
---
>     name: ice
26c28
<   name: microverse-dashboard-cihangir
---
>   name: microverse-bootstrap-cihangir
36c38
<     targetPort: 3030
---
>     targetPort: 3040
38c40
<     name: dashboard
---
>     name: bootstrap
46c48
<   name: microverse-ice-cihangir
---
>   name: microverse-dashboard-cihangir
56c58
<     targetPort: 3033
---
>     targetPort: 3030
58c60
<     name: ice
---
>     name: dashboard
66c68
<   name: microverse-bootstrap-cihangir
---
>   name: microverse-app-cihangir
76c78
<     targetPort: 3040
---
>     targetPort: 3000
78c80
<     name: bootstrap
---
>     name: app
82a85,86
>
>
```

only the lines of the service definitions are different, that is due to the ordering of the values.yaml::ports variable.